### PR TITLE
Feat: Develop the main function of Step1

### DIFF
--- a/src/components/Books/BookReviewForm.tsx
+++ b/src/components/Books/BookReviewForm.tsx
@@ -1,15 +1,17 @@
 import { css } from '@emotion/react';
+import { FormProvider, useForm } from 'react-hook-form';
 
 import useFormStep from './hooks/useFormStep';
 import useScreenSize from '@/hooks/useScreenSize';
 
 import BookPreview from './BookPreview';
 import FormHeader from './form/FormHeader';
-import { Step1, Step2, Step3, Step4, Step5, FormStep } from './step';
 import ProgressBar from '@/components/common/Progressbar/ProgressBar';
+import { Step1, Step2, Step3, Step4, Step5, Step6, FormStep } from './step';
 
-import { Step } from '@/types/forms';
 import { colors } from '@/styles/colors';
+import { BookFormData, Step } from '@/types/forms';
+import { INIT_FORM_DATA } from '@/constants/form';
 
 const steps: Step[] = [
   { Component: Step1, key: 'step1' },
@@ -17,6 +19,7 @@ const steps: Step[] = [
   { Component: Step3, key: 'step3' },
   { Component: Step4, key: 'step4' },
   { Component: Step5, key: 'step5' },
+  { Component: Step6, key: 'step6' },
 ];
 
 const BookReviewFormContainerStyles = css({
@@ -43,27 +46,43 @@ const BookReviewFormStyles = ({ isDesktop }: { isDesktop: boolean }) => {
 };
 
 const BookReviewForm = () => {
+  const form = useForm<BookFormData>({
+    mode: 'onChange',
+    defaultValues: INIT_FORM_DATA,
+    shouldFocusError: true,
+  });
   const { isDesktop } = useScreenSize({ width: 1024 });
-  const { nowStep, nextStep, prevStep, isLastStep } = useFormStep(steps.length); // 폼 스텝 관리
+  const { nowStep, nextStep, prevStep, isLastStep, isLastInputStep, initStep } = useFormStep(
+    steps.length,
+  ); // 폼 스텝 관리
+
+  const onSubmit = (data: BookFormData) => {
+    console.log(data);
+  };
 
   return (
     <div css={BookReviewFormContainerStyles}>
       <FormHeader />
       <ProgressBar step={nowStep} totalStep={5} color={colors.primary} size="full" />
 
-      <div css={BookReviewFormStyles({ isDesktop })}>
-        {/* 도서 정보 입력 폼 */}
-        <FormStep
-          steps={steps}
-          nowStep={nowStep}
-          nextStep={nextStep}
-          prevStep={prevStep}
-          isLastStep={isLastStep}
-        />
+      <FormProvider {...form}>
+        <form css={BookReviewFormStyles({ isDesktop })} onSubmit={form.handleSubmit(onSubmit)}>
+          {/* 도서 정보 입력 폼 */}
+          <FormStep
+            form={form}
+            steps={steps}
+            nowStep={nowStep}
+            nextStep={nextStep}
+            prevStep={prevStep}
+            isLastStep={isLastStep}
+            isLastInputStep={isLastInputStep}
+            initStep={initStep}
+          />
 
-        {/* 데스크탑 모드일 때만 Preview 표시 */}
-        {isDesktop && <BookPreview />}
-      </div>
+          {/* 데스크탑 모드일 때만 Preview 표시 */}
+          {isDesktop && <BookPreview />}
+        </form>
+      </FormProvider>
     </div>
   );
 };

--- a/src/components/Books/hooks/useFormStep.tsx
+++ b/src/components/Books/hooks/useFormStep.tsx
@@ -17,9 +17,14 @@ const useFormStep = (stepLength: number) => {
     setStep(step - 1);
   };
 
-  const isLastStep = step === stepLength - 1;
+  const initStep = () => {
+    setStep(0);
+  };
 
-  return { nowStep: step, nextStep, prevStep, isLastStep };
+  const isLastStep = step === stepLength - 1; // 마지막 스텝
+  const isLastInputStep = step === stepLength - 2; // form 정보 입력하는 마지막 스텝
+
+  return { nowStep: step, nextStep, prevStep, isLastInputStep, isLastStep, initStep };
 };
 
 export default useFormStep;

--- a/src/components/Books/step/FormStep.tsx
+++ b/src/components/Books/step/FormStep.tsx
@@ -24,6 +24,7 @@ const FormButtonStyles = css({
   justifyContent: 'space-between',
   width: '100%',
   gap: '10px',
+  marginTop: '20px',
 });
 
 const FormStep = ({

--- a/src/components/Books/step/Step1.tsx
+++ b/src/components/Books/step/Step1.tsx
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react';
 
-import { LabeledInput } from '@/components/common';
+import { RHFLabeledInput, RHFLabeledSelect } from '@/components/common';
+
+import { validateStep1 } from '@/utils/validateRule';
+
+import { BookFormData } from '@/types/forms';
+import { READING_STATUS_OPTIONS } from '@/constants/form';
+import { useFormContext } from 'react-hook-form';
 
 const Step1Styles = css({
   display: 'flex',
@@ -16,43 +22,109 @@ const InputContainerStyles = css({
   alignItems: 'flex-start',
   justifyContent: 'center',
   gap: '30px',
+
+  '@media (max-width: 525px)': {
+    gap: '16px',
+  },
+});
+
+const InputRowStyles = css({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '16px',
+  width: '100%',
+
+  '@media (max-width: 525px)': {
+    flexDirection: 'column',
+  },
 });
 
 const Step1 = () => {
+  const { watch } = useFormContext();
   return (
     <div css={Step1Styles}>
       <h2>도서 기본 정보</h2>
       <div css={InputContainerStyles}>
-        <LabeledInput
-          label="도서 제목"
-          name="title"
-          placeholder="도서 제목을 입력해주세요."
-          size="full"
-        />
-        <LabeledInput
-          label="도서 저자"
-          name="author"
-          placeholder="도서 저자를 입력해주세요."
-          size="full"
-        />
-        <LabeledInput
-          label="도서 출판사"
-          name="publisher"
-          placeholder="도서 출판사를 입력해주세요."
-          size="full"
-        />
-        <LabeledInput
-          label="도서 출판일"
-          name="publicationDate"
-          placeholder="도서 출판일을 입력해주세요."
-          size="full"
-        />
-        <LabeledInput
-          label="총 페이지 수"
-          name="pageCount"
-          placeholder="총 페이지 수를 입력해주세요."
-          size="full"
-        />
+        <div css={InputRowStyles}>
+          <RHFLabeledInput<BookFormData>
+            label="도서 제목"
+            name="title"
+            placeholder="도서 제목을 입력해주세요."
+            size="full"
+            rules={{ required: '도서 제목을 입력해주세요.' }}
+          />
+          <RHFLabeledInput<BookFormData>
+            name="author"
+            label="도서 저자"
+            placeholder="도서 저자를 입력해주세요."
+            size="full"
+            rules={{ required: '도서 저자를 입력해주세요.' }}
+          />
+        </div>
+        <div css={InputRowStyles}>
+          <RHFLabeledInput<BookFormData>
+            label="도서 출판사"
+            name="publisher"
+            placeholder="도서 출판사를 입력해주세요."
+            size="full"
+            rules={{ required: '도서 출판사를 입력해주세요.' }}
+          />
+          <RHFLabeledInput<BookFormData>
+            label="도서 출판일"
+            name="publishedDate"
+            placeholder="도서 출판일을 입력해주세요."
+            type="date"
+            size="full"
+            rules={{ required: '도서 출판일을 입력해주세요.' }}
+          />
+        </div>
+        <div css={InputRowStyles}>
+          <RHFLabeledInput<BookFormData>
+            label="총 페이지 수"
+            name="pageCount"
+            placeholder="총 페이지 수를 입력해주세요."
+            min={1}
+            type="number"
+            size="full"
+            rules={{
+              min: { value: 1, message: '페이지 수를 다시 입력해주세요.' },
+            }}
+          />
+          <RHFLabeledSelect<BookFormData>
+            label="독서 상태"
+            size="full"
+            name="readStatus"
+            defaultValue=""
+            options={READING_STATUS_OPTIONS}
+            rules={{ required: '독서 상태를 선택해주세요.' }}
+          />
+        </div>
+        <div css={InputRowStyles}>
+          <RHFLabeledInput<BookFormData>
+            label="독서 시작일"
+            name="startDate"
+            placeholder="독서 시작일을 입력해주세요."
+            type="date"
+            size="full"
+            disabled={watch('readStatus') === 'wantToRead' && watch('readStatus') !== ''}
+            rules={{
+              validate: (value, formValues) =>
+                validateStep1.startDate(value, formValues as BookFormData),
+            }}
+          />
+          <RHFLabeledInput<BookFormData>
+            label="독서 완료일"
+            name="endDate"
+            placeholder="독서 완료일을 입력해주세요."
+            type="date"
+            size="full"
+            disabled={watch('readStatus') !== 'read' && watch('readStatus') !== ''}
+            rules={{
+              validate: (value, formValues) =>
+                validateStep1.endDate(value, formValues as BookFormData),
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/Books/step/Step4.tsx
+++ b/src/components/Books/step/Step4.tsx
@@ -4,9 +4,10 @@ import { css } from '@emotion/react';
 import { BaseButton, LabeledTextarea, UnStylishButton } from '@/components/common';
 import DeleteIcon from '@/components/common/Icon/DeleteIcon';
 
+import { Quote } from '@/types/forms';
 import { colors } from '@/styles/colors';
 
-const Step3Styles = css({
+const Step4Styles = css({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
@@ -49,13 +50,6 @@ const DeleteButtonStyles = css({
   color: colors.gray,
 });
 
-interface Quote {
-  id: number;
-  label: string;
-  name: string;
-  value: string;
-}
-
 const Step4 = () => {
   const [quotes, setQuotes] = useState<Quote[]>([
     {
@@ -87,7 +81,7 @@ const Step4 = () => {
   };
 
   return (
-    <div css={Step3Styles}>
+    <div css={Step4Styles}>
       <h2>인용구</h2>
       <div css={TextContainerStyles}>
         <span>기억하고 싶은 인용구를 추가해주세요.</span>

--- a/src/components/Books/step/Step5.tsx
+++ b/src/components/Books/step/Step5.tsx
@@ -5,7 +5,7 @@ import { BaseButton } from '@/components/common';
 
 import { colors } from '@/styles/colors';
 
-const Step2Styles = css({
+const Step5Styles = css({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
@@ -37,7 +37,7 @@ const Step5 = () => {
   const [isRecommended, setIsRecommended] = useState(true);
 
   return (
-    <div css={Step2Styles}>
+    <div css={Step5Styles}>
       <h2>공개 설정</h2>
       <div css={TextContainerStyles}>
         <span>다른 사람들에게 이 도서를 공개하시겠습니까?</span>

--- a/src/components/Books/step/Step6.tsx
+++ b/src/components/Books/step/Step6.tsx
@@ -1,0 +1,35 @@
+import { css } from '@emotion/react';
+
+import { colors } from '@/styles/colors';
+
+const Step6Styles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  height: '100%',
+  gap: '200px',
+});
+
+const TextContainerStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '20px',
+  gap: '10px',
+  fontSize: '16px',
+  color: colors.gray,
+});
+
+const Step6 = () => {
+  return (
+    <div css={Step6Styles}>
+      <h2>도서 등록 완료</h2>
+      <div css={TextContainerStyles}>
+        <span>도서 등록이 완료되었습니다.</span>
+      </div>
+    </div>
+  );
+};
+
+export default Step6;

--- a/src/components/Books/step/index.ts
+++ b/src/components/Books/step/index.ts
@@ -3,4 +3,5 @@ export { default as Step2 } from './Step2';
 export { default as Step3 } from './Step3';
 export { default as Step4 } from './Step4';
 export { default as Step5 } from './Step5';
+export { default as Step6 } from './Step6';
 export { default as FormStep } from './FormStep';

--- a/src/components/common/Button/BaseButton.tsx
+++ b/src/components/common/Button/BaseButton.tsx
@@ -52,7 +52,7 @@ interface BaseButtonProps extends BaseButtonStylesProps {
 
 const BaseButton = (props: BaseButtonProps) => {
   return (
-    <button css={baseButtonStyles(props)} {...props}>
+    <button css={baseButtonStyles(props)} type={props.type || 'button'} {...props}>
       {props.children}
     </button>
   );

--- a/src/components/common/Input/BaseInput.tsx
+++ b/src/components/common/Input/BaseInput.tsx
@@ -50,6 +50,21 @@ const baseInputStyles = (props: BaseInputStylesProps) => {
       opacity: 0.6,
       backgroundColor: colors.lightGray,
     },
+
+    '&[type="date"]': {
+      position: 'relative',
+      '&::-webkit-calendar-picker-indicator': {
+        position: 'absolute',
+        right: '12px',
+        width: '16px',
+        height: '16px',
+        cursor: 'pointer',
+        zIndex: 10,
+      },
+      '&::-webkit-datetime-edit': {
+        paddingRight: '24px',
+      },
+    },
   });
 };
 

--- a/src/components/common/Input/BaseInput.tsx
+++ b/src/components/common/Input/BaseInput.tsx
@@ -2,20 +2,18 @@ import { css } from '@emotion/react';
 import { colors } from '@/styles/colors';
 
 type InputColor = 'primary' | 'secondary' | 'error';
-type InputVariant = 'contained' | 'outlined';
 type InputSize = 'small' | 'medium' | 'large' | 'full';
 
 interface BaseInputStylesProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'color'> {
   color?: InputColor;
-  variant?: InputVariant;
   size?: InputSize;
   error?: string;
   helperText?: string;
 }
 
 const baseInputStyles = (props: BaseInputStylesProps) => {
-  const { color = 'primary', variant = 'outlined', size = 'medium', disabled } = props;
+  const { color = 'primary', size = 'medium', disabled, error } = props;
 
   return css({
     border: 'none',
@@ -24,12 +22,8 @@ const baseInputStyles = (props: BaseInputStylesProps) => {
     alignItems: 'center',
     width: size === 'full' ? '100%' : 'fit-content',
     height: size === 'full' ? '40px' : 'auto',
-    backgroundColor:
-      variant === 'contained' ? (disabled ? colors.lightGray : colors.white) : 'transparent',
-    outline:
-      variant === 'outlined'
-        ? `2px solid ${color === 'error' ? colors.error : colors.lightGray}`
-        : '2px solid transparent',
+    backgroundColor: disabled ? colors.lightGray : colors.white,
+    outline: `2px solid ${error ? colors.error : colors.lightGray}`,
     padding: size === 'small' ? '8px 12px' : '12px',
     fontSize: size === 'small' ? '12px' : size === 'medium' ? '14px' : '16px',
     fontWeight: 'semibold',
@@ -97,10 +91,10 @@ const baseInputHelperTextStyles = css({
 });
 
 const BaseInput = ({ error, helperText, ...restProps }: BaseInputStylesProps) => {
-  const { color, variant, size, ...props } = restProps;
+  const { color, size, ...props } = restProps;
   return (
     <div css={baseInputWrapperStyles}>
-      <input css={baseInputStyles({ color, variant, size, ...props })} {...props} />
+      <input css={baseInputStyles({ color, size, error, ...props })} {...props} />
       {(error || helperText) && (
         <div css={baseInputTextWrapperStyles({ error })}>
           {error && <p css={baseInputErrorStyles}>{error}</p>}

--- a/src/components/common/Input/RHFLabeledInput.tsx
+++ b/src/components/common/Input/RHFLabeledInput.tsx
@@ -1,0 +1,33 @@
+import { FieldValues, Path, RegisterOptions, useFormContext } from 'react-hook-form';
+
+import LabeledInput from './LabeledInput';
+
+interface RHFLabeledInputProps<T extends FieldValues>
+  extends Omit<React.ComponentProps<typeof LabeledInput>, 'name'> {
+  name: Path<T>;
+  rules?: RegisterOptions<FieldValues, Path<T>>;
+  label: string;
+}
+
+const RHFLabeledInput = <T extends FieldValues>({
+  name,
+  label,
+  rules,
+  ...restProps
+}: RHFLabeledInputProps<T>) => {
+  const {
+    formState: { errors },
+    register,
+  } = useFormContext();
+
+  return (
+    <LabeledInput
+      label={label}
+      {...restProps}
+      {...register(name, rules)}
+      error={errors[name]?.message as string}
+    />
+  );
+};
+
+export default RHFLabeledInput;

--- a/src/components/common/Select/BaseSelect.tsx
+++ b/src/components/common/Select/BaseSelect.tsx
@@ -2,13 +2,11 @@ import { css } from '@emotion/react';
 import { colors } from '@/styles/colors';
 
 type SelectColor = 'primary' | 'secondary' | 'error';
-type SelectVariant = 'contained' | 'outlined';
 type SelectSize = 'small' | 'medium' | 'large' | 'full';
 
 interface BaseSelectStylesProps
   extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size' | 'color'> {
   color?: SelectColor;
-  variant?: SelectVariant;
   size?: SelectSize;
   error?: string;
   helperText?: string;
@@ -26,7 +24,7 @@ const baseSelectWrapperStyles = (props: BaseSelectStylesProps) => {
 };
 
 const baseSelectStyles = (props: BaseSelectStylesProps) => {
-  const { color = 'primary', variant = 'outlined', size = 'medium', disabled = false } = props;
+  const { color = 'primary', size = 'medium', error, disabled = false } = props;
 
   return css({
     border: 'none',
@@ -44,12 +42,8 @@ const baseSelectStyles = (props: BaseSelectStylesProps) => {
               ? '200px'
               : 'fit-content',
     height: size === 'full' ? '40px' : size === 'small' ? '30px' : '40px',
-    backgroundColor:
-      variant === 'contained' ? (disabled ? colors.lightGray : colors.white) : 'transparent',
-    outline:
-      variant === 'outlined'
-        ? `2.5px solid ${color === 'error' ? colors.error : colors.lightGray}`
-        : '2.5px solid transparent',
+    backgroundColor: disabled ? colors.lightGray : colors.white,
+    outline: `2.5px solid ${error ? colors.error : colors.lightGray}`,
     padding: size === 'small' ? '8px 12px' : '12px 12px',
     fontSize: size === 'small' ? '12px' : size === 'medium' ? '14px' : '16px',
     fontWeight: 'semibold',
@@ -67,7 +61,7 @@ const baseSelectStyles = (props: BaseSelectStylesProps) => {
     },
 
     '&:blur': {
-      outline: variant === 'outlined' ? `2.5px solid ${colors.lightGray}` : 'none',
+      outline: `2.5px solid ${colors.lightGray}`,
       outlineOffset: '2px',
     },
 
@@ -108,11 +102,11 @@ interface BaseSelectProps extends BaseSelectStylesProps {
 }
 
 const BaseSelect = ({ options, error, helperText, ...restProps }: BaseSelectProps) => {
-  const { color, variant, size, ...props } = restProps;
+  const { color, size, ...props } = restProps;
 
   return (
     <div css={baseSelectWrapperStyles({ size })}>
-      <select css={baseSelectStyles({ color, variant, size, ...props })} {...props}>
+      <select css={baseSelectStyles({ color, size, error, ...props })} {...props}>
         {options.map(({ key, value, label }, index) => (
           <option key={key || label || value || `${index}-${value}`} value={value}>
             {label}

--- a/src/components/common/Select/LabeledSelect.tsx
+++ b/src/components/common/Select/LabeledSelect.tsx
@@ -14,6 +14,7 @@ const labeledSelectWrapperStyles = css({
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',
+  width: '100%',
 });
 
 const LabeledSelect = ({

--- a/src/components/common/Select/RHFLabeledSelect.tsx
+++ b/src/components/common/Select/RHFLabeledSelect.tsx
@@ -1,0 +1,33 @@
+import { FieldValues, Path, RegisterOptions, useFormContext } from 'react-hook-form';
+
+import LabeledSelect from './LabeledSelect';
+
+interface RHFLabeledSelectProps<T extends FieldValues>
+  extends Omit<React.ComponentProps<typeof LabeledSelect>, 'name'> {
+  name: Path<T>;
+  rules?: RegisterOptions<FieldValues, Path<T>>;
+  label: string;
+}
+
+const RHFLabeledSelect = <T extends FieldValues>({
+  name,
+  label,
+  rules,
+  ...restProps
+}: RHFLabeledSelectProps<T>) => {
+  const {
+    formState: { errors },
+    register,
+  } = useFormContext();
+
+  return (
+    <LabeledSelect
+      label={label}
+      {...restProps}
+      {...register(name, rules)}
+      error={errors[name]?.message as string}
+    />
+  );
+};
+
+export default RHFLabeledSelect;

--- a/src/components/common/Textarea/RHFLabeledTextarea.tsx
+++ b/src/components/common/Textarea/RHFLabeledTextarea.tsx
@@ -1,0 +1,33 @@
+import { FieldValues, Path, RegisterOptions, useFormContext } from 'react-hook-form';
+
+import LabeledTextarea from './LabeledTextarea';
+
+interface RHFLabeledTextareaProps<T extends FieldValues>
+  extends Omit<React.ComponentProps<typeof LabeledTextarea>, 'name'> {
+  name: Path<T>;
+  rules?: RegisterOptions<FieldValues, Path<T>>;
+  label: string;
+}
+
+const RHFLabeledTextarea = <T extends FieldValues>({
+  name,
+  label,
+  rules,
+  ...restProps
+}: RHFLabeledTextareaProps<T>) => {
+  const {
+    formState: { errors },
+    register,
+  } = useFormContext();
+
+  return (
+    <LabeledTextarea
+      label={label}
+      {...restProps}
+      {...register(name, rules)}
+      error={errors[name]?.message as string}
+    />
+  );
+};
+
+export default RHFLabeledTextarea;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -17,3 +17,8 @@ export { default as LabeledTextarea } from './Textarea/LabeledTextarea';
 /* Icons */
 export { default as StarIcon } from './Icon/StarIcon';
 export { default as DeleteIcon } from './Icon/DeleteIcon';
+
+/* RHF */
+export { default as RHFLabeledInput } from './Input/RHFLabeledInput';
+export { default as RHFLabeledSelect } from './Select/RHFLabeledSelect';
+export { default as RHFLabeledTextarea } from './Textarea/RHFLabeledTextarea';

--- a/src/constants/form.tsx
+++ b/src/constants/form.tsx
@@ -1,4 +1,11 @@
-import { BookFormData } from '@/types/forms';
+import {
+  BookFormData,
+  Step1FormData,
+  Step2FormData,
+  Step3FormData,
+  Step4FormData,
+  Step5FormData,
+} from '@/types/forms';
 
 export const READING_STATUS_OPTIONS: { label: string; value: string }[] = [
   { label: '독서 상태를 선택해주세요.', value: '' },
@@ -8,7 +15,7 @@ export const READING_STATUS_OPTIONS: { label: string; value: string }[] = [
   { label: '보류 중', value: 'holding' },
 ];
 
-export const INIT_FORM_DATA: BookFormData = {
+export const INIT_STEP1_FORM_DATA: Step1FormData = {
   title: '',
   author: '',
   publisher: '',
@@ -17,9 +24,18 @@ export const INIT_FORM_DATA: BookFormData = {
   readStatus: '',
   startDate: '',
   endDate: '',
+};
+
+export const INIT_STEP2_FORM_DATA: Step2FormData = {
   isRecommended: true,
   rating: 0,
+};
+
+export const INIT_STEP3_FORM_DATA: Step3FormData = {
   review: '',
+};
+
+export const INIT_STEP4_FORM_DATA: Step4FormData = {
   quotes: [
     {
       id: 0,
@@ -28,5 +44,16 @@ export const INIT_FORM_DATA: BookFormData = {
       value: '',
     },
   ],
+};
+
+export const INIT_STEP5_FORM_DATA: Step5FormData = {
   isPublic: false,
+};
+
+export const INIT_FORM_DATA: BookFormData = {
+  ...INIT_STEP1_FORM_DATA,
+  ...INIT_STEP2_FORM_DATA,
+  ...INIT_STEP3_FORM_DATA,
+  ...INIT_STEP4_FORM_DATA,
+  ...INIT_STEP5_FORM_DATA,
 };

--- a/src/constants/form.tsx
+++ b/src/constants/form.tsx
@@ -1,0 +1,32 @@
+import { BookFormData } from '@/types/forms';
+
+export const READING_STATUS_OPTIONS: { label: string; value: string }[] = [
+  { label: '독서 상태를 선택해주세요.', value: '' },
+  { label: '읽고 싶은 책', value: 'wantToRead' },
+  { label: '읽는 중', value: 'reading' },
+  { label: '읽은 책', value: 'read' },
+  { label: '보류 중', value: 'holding' },
+];
+
+export const INIT_FORM_DATA: BookFormData = {
+  title: '',
+  author: '',
+  publisher: '',
+  publishedDate: '',
+  pageCount: 0,
+  readStatus: '',
+  startDate: '',
+  endDate: '',
+  isRecommended: true,
+  rating: 0,
+  review: '',
+  quotes: [
+    {
+      id: 0,
+      label: '인용구',
+      name: 'quote',
+      value: '',
+    },
+  ],
+  isPublic: false,
+};

--- a/src/types/forms.ts
+++ b/src/types/forms.ts
@@ -2,3 +2,48 @@ export type Step = {
   Component: React.ComponentType;
   key: string;
 };
+
+export type ReadStatus = 'wantToRead' | 'reading' | 'read' | 'holding' | '';
+
+export interface Step1FormData {
+  title: string; // 도서 제목
+  author: string; // 도서 저자
+  publisher: string; // 도서 출판사
+  publishedDate: string; // 도서 출판일
+  pageCount: number; // 도서 페이지 수
+  readStatus: ReadStatus; // 독서 상태
+  startDate?: string; // 독서 시작일
+  endDate?: string; // 독서 완료일
+}
+
+export interface Step2FormData {
+  isRecommended: boolean; // 추천 여부
+  rating?: number; // 독서 평점
+}
+
+export interface Step3FormData {
+  review?: string; // 독후감
+}
+
+/** 인용구 */
+export type Quote = {
+  id: number;
+  label: string;
+  name: string;
+  value: string;
+};
+
+export interface Step4FormData {
+  quotes: Quote[];
+}
+
+export interface Step5FormData {
+  isPublic: boolean; // 공개 여부
+}
+
+export interface BookFormData
+  extends Step1FormData,
+    Step2FormData,
+    Step3FormData,
+    Step4FormData,
+    Step5FormData {}

--- a/src/utils/validateRule.ts
+++ b/src/utils/validateRule.ts
@@ -1,0 +1,39 @@
+import { BookFormData } from '@/types/forms';
+
+export const validateStep1 = {
+  /** 독서 시작일 검증 */
+  startDate: (value: string, formValues: BookFormData) => {
+    const { readStatus, publishedDate } = formValues;
+    if (publishedDate && new Date(value) < new Date(publishedDate)) {
+      return '독서 시작일은 출판일 이후여야 합니다.';
+    }
+    if (readStatus !== 'wantToRead' && !value) {
+      return '독서 시작일을 입력해주세요.';
+    }
+    return true;
+  },
+
+  /** 독서 완료일 검증 */
+  endDate: (value: string, formValues: BookFormData) => {
+    const { readStatus, startDate } = formValues;
+    if (readStatus === 'read' && startDate && value && new Date(value) < new Date(startDate)) {
+      return '독서 완료일은 독서 시작일 이후여야 합니다.';
+    }
+    if (readStatus === 'wantToRead' && value) {
+      return '읽고 싶은 책은 독서 기간을 입력할 수 없습니다.';
+    }
+    if (readStatus === 'reading' && value) {
+      return '읽고 있는 책은 독서 완료일을 입력할 수 없습니다.';
+    }
+    if (readStatus === 'holding' && value) {
+      return '보류 중인 책은 독서 완료일을 입력할 수 없습니다.';
+    }
+    if (readStatus === 'read' && !value) {
+      return '독서 완료일을 입력해주세요.';
+    }
+    if (readStatus === '' && !value) {
+      return '독서 완료일을 선택해주세요.';
+    }
+    return true;
+  },
+};


### PR DESCRIPTION
## 📌 Related Issue
close #11 

## 🚀 Description
RHF 컴포넌트 생성 및 Step1 Form 관리 기능을 추가했습니다.

### RHF 컴포넌트 생성
기존에 생성한Labeled Input, Labeled Select 컴포넌트를 RHF화 했습니다.
컴포넌트를 사용할 때 RHF register 등을 사용하지 않고 유효성 rules만 지정할 수 있도록, RHF 컴포넌트 내에서 구현을 시도했습니다.
RHFLabeledSelect로 생성해 컴포넌트 내부에서 register를 사용해 RHF 폼 관리를 진행합니다.

각 Step 컴포넌트에서 이를 사용할 때 register를 props로 전달하지 않고 사용하며,
상위 컴포넌트(루트)에서 RHF FormProvider를 사용하여 모든 Step에서 RHF context를 공유할 수 있습니다.

```javascript
const RHFLabeledSelect = <T extends FieldValues>({
  name,
  label,
  rules,
  ...restProps
}: RHFLabeledSelectProps<T>) => {
  const {
    formState: { errors },
    register,
  } = useFormContext();

  return (
    <LabeledSelect
      label={label}
      {...restProps}
      {...register(name, rules)}
      error={errors[name]?.message as string}
    />
  );
};

// 각 Step 컴포넌트에서 아래와 같이 사용
<RHFLabeledSelect<BookFormData>
  label="독서 상태"
  size="full"
  name="readStatus"
  defaultValue=""
  options={READING_STATUS_OPTIONS}
  rules={{ required: '독서 상태를 선택해주세요.' }}
/>
```


###  FormStep 폼 관리 및 유효성 검증
Form과 관련된 유효성 검증은 FormStep 컴포넌트에서 관리합니다.
Form의 [다음] 버튼을 클릭했을 때 해당 Step 컴포넌트의 모든 Field를 유효성 검증합니다.
이 때, Form rules에 따라 유효성 검증을 진행하며, 검증을 통과하지 못하면
각 필드에 error Outline과 error 메시지를 보여주고, 검증을 통과하지 못한 가장 첫번째 필드에 Focus를 적용합니다.

이 과정에서 필드 입력 없이 첫 렌더링 후 바로 유효성 검증을 진행하면 Field가 error Outline과 메시지 처리는 되지만, focus 이동이 되지 않는 문제를 겪었습니다.
원인을 분석한 결과, [다음] 버튼을 눌렀을 때 FormState의 업데이트 과정이 비동기적으로 처리되어,
유효성 검증 과정 중에 formState.errors 객체가 undefined로 정의되면서 setFocus가 정상적으로 진행되지 않았습니다.

필드를 입력하지 않고 유효성 검증을 진행할 경우라는 점에서 힌트를 얻어, RHF의 dirtyField 객체를 이용했습니다.
dirtyField는 사용자가 수정한, 즉 필드에 입력한 값을 반환하는 객체이며 필드 입력 없이 검증하는 경우 이 dirtyField 객체에 어떤 값도 없어야 한다고 생각했습니다.

이후 입력없이 진행하는 유효성 검증은 dirtyFields를, 어떤 필드라도 입력된 후 진행되는 유효성 검증은 errors 객체를 이용하도록 케이스를 분류했습니다.

```javascript
const isValid = await trigger(getCurrentStepFields(nowStep) as string[]);
const errors = formState.errors;
const dirtyFields = Object.keys(formState.dirtyFields);

// 전체 요소가 빈 경우 [다음]을 누르면 RHF formState가 비동기로 동작해
// formState의 error가 빈 객체로 나와 첫 렌더링 시 focus가 안되는 문제
// -> dirtyFields로 수정 여부를 확인하고, 전체가 빈 필드이면 포커스

if (!isValid && dirtyFields.length === 0) {
  const firstField = getCurrentStepFields(nowStep)[0];

  setFocus(firstField as string);
  return;
} else if (!isValid && errors) {
  const firstField = Object.keys(errors).find((field) => errors[field as keyof BookFormData]);

  setFocus(firstField as string);
  return;
}
```


기타 수정 사항
- 리뷰 작성이 종료되었다는 멘트를 보여줄 Step6를 추가했습니다.
- Input [type=date]의 캘린더 아이콘 위치를 수정했습니다.
- Form 관련 타입 및 초깃값을 지정했습니다.


## 📷 Screenshot
![화면 기록 2025-07-13 오전 3 17 33](https://github.com/user-attachments/assets/8ab7cc4b-80c5-4887-aedb-a9c2ed4470ca)

