### PR TITLE
Refactor: Prevent Re-rendering caused by using RHF watch with getValue

### DIFF
--- a/src/components/Books/step/Step2.tsx
+++ b/src/components/Books/step/Step2.tsx
@@ -50,6 +50,7 @@ const TextStyles = css({
 const Step2 = () => {
   const { watch, setValue } = useFormContext();
   const isRecommended = watch('isRecommended');
+  const rating = watch('rating');
 
   const handleRatingChange = (value: number) => {
     setValue('rating', value);
@@ -83,7 +84,7 @@ const Step2 = () => {
         <span css={css(TextStyles, { fontSize: '20px', marginBottom: '20px' })}>
           별점을 선택해주세요.
         </span>
-        <Rating size={40} value={watch('rating')} onChange={handleRatingChange} />
+        <Rating size={40} value={rating} onChange={handleRatingChange} />
         <span css={TextStyles}>별점은 1점 또는 5점을 선택하신 경우</span>
         <span css={TextStyles}>다음 단계에서 독후감을 필수로 작성해야 합니다.</span>
       </div>

--- a/src/components/Books/step/Step3.tsx
+++ b/src/components/Books/step/Step3.tsx
@@ -33,9 +33,11 @@ const InputContainerStyles = css({
 });
 
 const Step3 = () => {
-  const { watch } = useFormContext();
+  const { watch, getValues } = useFormContext();
+
+  // review -> 필드 글자 수 체크(실시간), rating -> 이전 step 별점(실시간 x)
   const review = watch('review');
-  const rating = watch('rating');
+  const rating = getValues('rating');
 
   return (
     <div css={Step3Styles}>


### PR DESCRIPTION
## 📌 Related Issue
#16 

## 🚀 Description
watch로 추적하던 form 상태를 getValues로 받아오도록 일부 수정했습니다.

### Step1
Step1의 독서 시작일/완료일의 경우 [독서 상태] 필드의 값에 따라 disabled 여부가 결정되어야 하므로
getValues가 아닌 watch를 사용해 실시간 상태 추적을 진행해야 했습니다.

### Step2
Step2의 독후감(review), 별점(rating)의 경우 각 값에 따라 실시간으로 UI가 변해야 하는 특성으로 인해 이전 그대로 watch를 사용합니다.
기존에 Rating 컴포넌트에서 인라인으로 사용하던 방식을 변수로 선언해 사용하도록 변경했습니다.
`<Rating value={watch(rating)} ... />` -> `<Rating value={rating} .../>`

### Step3
Step3의 경우 이전 Step3 작업 시 필요에 따라 getValues와 watch를 적절하게 사용해 변경 및 특이 사항 없습니다.